### PR TITLE
Update df-ufpb.cls

### DIFF
--- a/df-ufpb.cls
+++ b/df-ufpb.cls
@@ -629,7 +629,7 @@
 
 \newcommand{\sumario}{%
   \ifpdf%
-  \pdfbookmark[1]{\contentsname}{sumario}
+  \pdfbookmark[0]{\contentsname}{sumario}
   \fi
   \tableofcontents%
   \thispagestyle{empty}%


### PR DESCRIPTION
Coloca o Sumário fora da seção "Elementos Pré-textuais" dos PDFBookmarks.