### PR TITLE
Remove imposição de honoríficos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ Informar o nome do(a) autor(a) no formato "Sobrenome, Nome".
 
 ### `\orientador{}` ou `\orientadora{}` (obrigatório ao menos um)
 
-Informar o(a) orientador(a) do trabalho.
+Informar o(a) orientador(a) do trabalho. Honoríficos tais como "Professora Doutora" ou "Prof. Dr." podem acompanhar o nome, caso desejado.
 
 ### `\coorientador{}` ou `\coorientadora{}` (opcional)
 
-Informar o(a) coorientador(a) do trabalho, caso houver.
+Informar o(a) coorientador(a) do trabalho, caso houver. Honoríficos tais como "Professora Doutora" ou "Prof. Dr." podem acompanhar o nome, caso desejado.
 
 ### `\chaves{}` (obrigatório)
 
@@ -153,7 +153,7 @@ Gera uma folha de rosto.
 
 ### `\begin{aprovacao}` [...] `\end{aprovacao}`
 
-Ambiente para geração da folha de aprovação da banca. O(a) presidente da banca já fica preenchido, assumindo os dados do(a) orientador(a). Para os demais membros, usar o comando `\membro{}{}{}` dentro do ambiente. O primeiro argumento é o nome (com titulação), o segundo é a filiação, o terceiro é função na banca (avaliador(a), arguidor(a), coorientador(a), etc.).
+Ambiente para geração da folha de aprovação da banca. O(a) presidente da banca já fica preenchido, assumindo os dados do(a) orientador(a). Para os demais membros, usar o comando `\membro{}{}{}` dentro do ambiente. O primeiro argumento é o nome (possivelmente acompanhado de titulação, ou honoríficos, caso desejado), o segundo é a filiação, o terceiro é a função na banca (avaliador(a), arguidor(a), coorientador(a), etc.).
 
 
 ### `\ata{}`

--- a/df-ufpb.cls
+++ b/df-ufpb.cls
@@ -375,15 +375,15 @@
            \textsf{Linha de Pesquisa:} & \ufpb@linhadepesquisa{}\\[4pt]
          }%
          \ifthenelse{\isundefined{\ufpb@orientadora}}{%
-           \textsf{Orientador:}     & Prof. Dr. \ufpb@orientador{}\\
+           \textsf{Orientador:}        & \ufpb@orientador{}\\
          }{%
-           \textsf{Orientadora:}     & Profa. Dra. \ufpb@orientadora{}\\
+           \textsf{Orientadora:}       & \ufpb@orientadora{}\\
          }%
          \ifthenelse{\NOT\isundefined{\ufpb@coorientadora}}{%
-           \textsf{Coorientadora:}     & Profa. Dra. \ufpb@coorientadora{}
+           \textsf{Coorientadora:}     & \ufpb@coorientadora{}
          }{}%
          \ifthenelse{\NOT\isundefined{\ufpb@coorientador}}{%
-           \textsf{Coorientador:}     & Prof. Dr. \ufpb@coorientador{}
+           \textsf{Coorientador:}      & \ufpb@coorientador{}
          }{}%
        \end{tabular}
      \end{minipage}
@@ -425,11 +425,11 @@
        \ufpb@autorx{}. -- \ufpb@ano{}. & \\
        & \lastpageref{LastPages}f. & \\[0.5cm]
        & \ifthenelse{\isundefined{\ufpb@orientadora}}{%
-         Orientador: Prof. \ufpb@orientador{}}{Orientadora: Profa. \ufpb@orientadora{}}
+         Orientador: \ufpb@orientador{}}{Orientadora: \ufpb@orientadora{}}
        \ifthenelse{\isundefined{\ufpb@coorientador}}{}{%
-         ; Co-Orientador: Prof. \ufpb@coorientador{}}
+         ; Co-Orientador: \ufpb@coorientador{}}
        \ifthenelse{\isundefined{\ufpb@coorientadora}}{}{%
-         ; Co-Orientadora: Profa. \ufpb@coorientadora{}} & \\
+         ; Co-Orientadora: \ufpb@coorientadora{}} & \\
        & \ufpb@documento{} (\ufpb@curso{}) -- \ufpb@universidade{}, %
        \ufpb@unidade{}, \ufpb@ano{}. & \\[0.5cm]
        & \ufpb@inclui{} & \\[1cm]
@@ -478,8 +478,8 @@
    \begin{center}
      \rule{0.8\textwidth}{0.4pt}\linebreak
      \ifthenelse{\isundefined{\ufpb@orientadora}}{%
-       \textbf{Prof. Dr. \ufpb@orientador}\linebreak}{%
-       \textbf{Profa. Dra. \ufpb@orientadora}\linebreak}%
+       \textbf{\ufpb@orientador}\linebreak}{%
+       \textbf{\ufpb@orientadora}\linebreak}%
      Presidente da Banca \vskip 30pt
 }{%
    \end{center}%

--- a/modelo.tex
+++ b/modelo.tex
@@ -40,8 +40,8 @@
 \rosto
 \ficha
 \begin{aprovacao}
-  \membro{Prof. Dr. Jean-Baptiste Joseph Fourier}{Universidade de Paris}{Arguidor}
-  \membro{Prof. Dr. Johann Carl Friedrich Gauss}{Universidade de Göttingen}{Arguidor}
+  \membro{Jean-Baptiste Joseph Fourier}{Universidade de Paris}{Arguidor}
+  \membro{Johann Carl Friedrich Gauss}{Universidade de Göttingen}{Arguidor}
 \end{aprovacao}
 \begin{dedicatoria}
 à Isabel do Palatinado, com admiração  


### PR DESCRIPTION
Isto talvez seja controverso.

A classe atualmente impõe os honoríficos "Prof(a). Dr(a)." para orientador(a) e membros da banca. Talvez seja melhor relegar isso ao gosto da freguesia. Pelas seguintes razões:

- Orientador(a) ou coorientador(a) que não possuam título de doutor(a), ou possuam mais outros títulos que poderiam ser listados
- Muita gente não liga mais pra esta pieguice de honoríficos acadêmicos (eu incluso)